### PR TITLE
WritWorthy provisioning bugfix: extra crafting attempt

### DIFF
--- a/Alchemy.lua
+++ b/Alchemy.lua
@@ -9,7 +9,7 @@
 -- File Name: Alchemy.lua
 -- File Description: Contains the functions for Alchemy
 -- Load Order Requirements: After LibLazyCrafting.lua
--- 
+--
 -----------------------------------------------------------------------------------
 
 
@@ -118,7 +118,7 @@ local function LLC_AlchemyCraftInteraction(event, station)
 	currentCraftAttempt.position = position
 	currentCraftAttempt.timestamp = GetTimeStamp()
 	currentCraftAttempt.addon = addon
-	currentCraftAttempt.prevSlots = LibLazyCrafting.findSlotsContaining(currentCraftAttempt.link,true)
+	currentCraftAttempt.prevSlots = LibLazyCrafting.backpackInventory()
 end
 
 local function LLC_AlchemyCraftingComplete(event, station, lastCheck)

--- a/Provisioning.lua
+++ b/Provisioning.lua
@@ -9,7 +9,7 @@
 -- File Name: Provisioning.lua
 -- File Description: Contains the functions for Provisioning
 -- Load Order Requirements: After LibLazyCrafting.lua
--- 
+--
 -----------------------------------------------------------------------------------
 
 
@@ -82,7 +82,7 @@ local function LLC_ProvisioningCraftInteraction(event, station)
     currentCraftAttempt.position = position
     currentCraftAttempt.timestamp = GetTimeStamp()
     currentCraftAttempt.addon = addon
-    currentCraftAttempt.prevSlots = LibLazyCrafting.findSlotsContaining(currentCraftAttempt.link)
+    currentCraftAttempt.prevSlots = LibLazyCrafting.backpackInventory()
 end
 
 local function LLC_ProvisioningCraftingComplete(event, station, lastCheck)


### PR DESCRIPTION
Would erroneously fail to recognize when a slot went from "empty" to "have some food" after a crafting attempt. This caused an unnecessary extra crafting attempt and stacks of 4 extra foods clogging the backpack.