### PR TITLE
Alchemy/Provisioning isItemCraftable material checks

### DIFF
--- a/Alchemy.lua
+++ b/Alchemy.lua
@@ -27,6 +27,10 @@ end
 
 local craftingQueue = LibLazyCrafting.craftingQueue
 
+local function getItemLinkFromItemId(itemId) local name = GetItemLinkName(ZO_LinkHandler_CreateLink("Test Trash", nil, ITEM_LINK_TYPE,itemId, 1, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 10000, 0))
+    return ZO_LinkHandler_CreateLink(zo_strformat("<<t:1>>",name), nil, ITEM_LINK_TYPE,itemId, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+end
+
 local function LLC_CraftAlchemyItemByItemId(self, solventId, reagentId1, reagentId2, reagentId3, timesToMake, autocraft, reference)
 	dbug('FUNCTION:LLCCraftAlchemy')
 	if reference == nil then reference = "" end
@@ -127,13 +131,25 @@ local function LLC_AlchemyCraftingComplete(event, station, lastCheck)
 
 end
 
+local function LLC_AlchemyIsItemCraftable(station, request)
+    if station ~= CRAFTING_TYPE_ALCHEMY then return false end
+
+    local materialList
+      = { { itemLink = getItemLinkFromItemId(request.solventId ) , requiredCt = request.timesToMake }
+        , { itemLink = getItemLinkFromItemId(request.reagentId1) , requiredCt = request.timesToMake }
+        , { itemLink = getItemLinkFromItemId(request.reagentId2) , requiredCt = request.timesToMake }
+        , { itemLink = getItemLinkFromItemId(request.reagentId3) , requiredCt = request.timesToMake }
+        }
+    return LibLazyCrafting.HaveMaterials(materialList)
+end
+
 LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_ALCHEMY] =
 {
 	["check"] = function(station) return station == CRAFTING_TYPE_ALCHEMY end,
 	['function'] = LLC_AlchemyCraftInteraction,
 	["complete"] = LLC_AlchemyCraftingComplete,
 	["endInteraction"] = function(station) --[[endInteraction()]] end,
-	["isItemCraftable"] = function(station) if station == CRAFTING_TYPE_ALCHEMY then return true else return false end end,
+	["isItemCraftable"] = LLC_AlchemyIsItemCraftable
 }
 
 LibLazyCrafting.functionTable.CraftAlchemyPotion = LLC_CraftAlchemyPotion

--- a/LibLazyCrafting.lua
+++ b/LibLazyCrafting.lua
@@ -289,6 +289,31 @@ function LibLazyCrafting.stackableCraftingComplete(event, station, lastCheck, cr
 	end
 end
 
+local function getItemLinkFromItemId(itemId) local name = GetItemLinkName(ZO_LinkHandler_CreateLink("Test Trash", nil, ITEM_LINK_TYPE,itemId, 1, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 10000, 0))
+    return ZO_LinkHandler_CreateLink(zo_strformat("<<t:1>>",name), nil, ITEM_LINK_TYPE,itemId, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+end
+
+function LibLazyCrafting.HaveMaterials(materialList)
+    for _, mat in ipairs(materialList) do
+        local itemLink = mat.itemLink
+        if (not itemLink) and mat.itemId then
+            itemLink = getItemLinkFromItemId(mat.itemId)
+        end
+        if itemLink then
+            local bagCt, bankCt, craftBagCt = GetItemLinkStacks(itemLink)
+            local haveCt = bagCt + bankCt + craftBagCt
+            if haveCt < mat.requiredCt then
+            			-- Zig: What's the correct way to report "skipping this
+            			-- request beccause you're out of Perfect Roe"?
+                d("LibLazyCrafting: insufficient materials: "..tostring(itemLink)
+                    ..": require "..tostring(mat.requiredCt)
+                    .."  have "..tostring(haveCt))
+                return false
+            end
+        end
+    end
+    return true
+end
 
 -------------------------------------
 -- QUEUE FUNCTIONS

--- a/Provisioning.lua
+++ b/Provisioning.lua
@@ -29,6 +29,10 @@ end
 
 local craftingQueue = LibLazyCrafting.craftingQueue
 
+local function getItemLinkFromItemId(itemId) local name = GetItemLinkName(ZO_LinkHandler_CreateLink("Test Trash", nil, ITEM_LINK_TYPE,itemId, 1, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 10000, 0))
+    return ZO_LinkHandler_CreateLink(zo_strformat("<<t:1>>",name), nil, ITEM_LINK_TYPE,itemId, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+end
+
 local function toRecipeLink(recipeId)
     return string.format("|H1:item:%s:3:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h", tostring(recipeId))
 end
@@ -89,13 +93,35 @@ local function LLC_ProvisioningCraftingComplete(event, station, lastCheck)
     LibLazyCrafting.stackableCraftingComplete(event, station, lastCheck, CRAFTING_TYPE_PROVISIONING, currentCraftAttempt)
 end
 
+local function LLC_ProvisioningIsItemCraftable(station, request)
+    if station ~= CRAFTING_TYPE_PROVISIONING then return false end
+
+    local materialList  = {}
+    local recipeLink    = getItemLinkFromItemId(request.recipeId)
+    local ingrCt        = GetItemLinkRecipeNumIngredients(recipeLink)
+    for ingrIndex = 1,ingrCt do
+        local _, _, ingrReqCt = GetItemLinkRecipeIngredientInfo(recipeLink, ingrIndex)
+        local ingrLink = GetItemLinkRecipeIngredientItemLink(recipeLink, ingrIndex, LINK_STYLE_DEFAULT)
+        if       ingrReqCt
+            and (0 < ingrReqCt)
+            and  ingrLink
+            and (ingrLink ~= "") then
+            local mat = { itemLink   = ingrLink
+                        , requiredCt = ingrReqCt * request.timesToMake
+                        }
+            table.insert(materialList, mat)
+        end
+    end
+    return LibLazyCrafting.HaveMaterials(materialList)
+end
+
 LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_PROVISIONING] =
 {
     ["check"] = function(station) return station == CRAFTING_TYPE_PROVISIONING end,
     ['function'] = LLC_ProvisioningCraftInteraction,
     ["complete"] = LLC_ProvisioningCraftingComplete,
     ["endInteraction"] = function(station) --[[endInteraction()]] end,
-    ["isItemCraftable"] = function(station) if station == CRAFTING_TYPE_PROVISIONING then return true else return false end end,
+    ["isItemCraftable"] = LLC_ProvisioningIsItemCraftable
 }
 
 LibLazyCrafting.functionTable.CraftProvisioningItemByRecipeId = LLC_CraftProvisioningItemByRecipeId


### PR DESCRIPTION
Do not attempt to craft alchemy or provisioning requests if we lack sufficient materials.

Avoids an infinite loop + disconnect.