### PR TITLE
Fix LibLazyCrafting issues

### DIFF
--- a/Enchanting.lua
+++ b/Enchanting.lua
@@ -87,7 +87,7 @@ local function LLC_CraftEnchantingGlyphItemID(self, potencyItemID, essenceItemID
 
 	--sortCraftQueue()
 	if GetCraftingInteractionType()==CRAFTING_TYPE_ENCHANTING then 
-		LibLazyCrafting.craftInteract(event, CRAFTING_TYPE_ENCHANTING)
+		LibLazyCrafting.craftInteract(nil, CRAFTING_TYPE_ENCHANTING)
 	end
 	return requestTable
 end
@@ -276,6 +276,8 @@ local function getEnchantingResultItemId(enchantId)
 end
 
 local function getEssenceInfoForResult(resultItemId)
+	local parity
+	local essenceId
 	for i = 1, #glyphInfo do
 		if glyphInfo[i][3] == resultItemId then
 			parity = -1
@@ -521,8 +523,8 @@ local function applyGlyphToItem(requestTable)
 			LibLazyCrafting.SendCraftEvent(LLC_ENCHANTMENT_FAILED, 0, requestTable.Requester, requestTable )
 			return
 		end
-		table.remove(glyphInfo)
-		local equipUniqueId = table.remove(equipInfo).uniqueId
+		table.remove(glyphInfo, i)
+		local equipUniqueId = table.remove(equipInfo, i).uniqueId
 		-- Enchanting too many too fast will get you kicked!
 		zo_callLater(function()
 			EnchantItem(equipBag, equipSlot, glyphBag , glyphSlot)
@@ -539,8 +541,8 @@ local function applyGlyphToItem(requestTable)
 		end, (numLoops-i+1)*260
 		
 		)
-		currentCraftAttempt = {}
 	end
+	currentCraftAttempt = {}
 end
 
 local function wasItemMade(bag, slot)
@@ -593,7 +595,7 @@ end
 
 local function LLC_EnchantingCraftingComplete(station, lastCheck)
 	if currentCraftAttempt.type == "deconstruct" then
-		LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_BLACKSMITHING]["complete"]( station, earliest, addon , position)
+		LibLazyCrafting.craftInteractionTables[CRAFTING_TYPE_BLACKSMITHING]["complete"]( station )
 		currentCraftAttempt.type = nil
 		return
 	end
@@ -606,7 +608,9 @@ local function LLC_EnchantingCraftingComplete(station, lastCheck)
 	local bag, slot = LibLazyCrafting.findNextSlotIndex(wasItemMade)
 	local found = false
 	local removedTable
+	local lastSlot
 	while slot ~= nil do
+		lastSlot = slot
 		removedTable = handleEnchantComplete(station, slot)
 		bag, slot = LibLazyCrafting.findNextSlotIndex(wasItemMade, slot+1)
 		found = true
@@ -617,13 +621,11 @@ local function LLC_EnchantingCraftingComplete(station, lastCheck)
 			return
 		else
 			local copiedTable = LibLazyCrafting.tableShallowCopy(removedTable)
-			copiedTable.slot = slot
+			copiedTable.slot = lastSlot
 			copiedTable.quantity = 1
 			LibLazyCrafting.SendCraftEvent(LLC_INITIAL_CRAFT_SUCCESS, station, removedTable.Requester, copiedTable)
 			return
 		end
-		currentCraftAttempt = {}
-		return
 	end
 
 	if lastCheck then
@@ -634,12 +636,12 @@ local function LLC_EnchantingCraftingComplete(station, lastCheck)
 			and GetItemLinkFunctionalQuality(GetItemLink(BAG_BACKPACK, lastSlotUsed,0)) == GetItemLinkFunctionalQuality(currentCraftAttempt.link) then
 				currentCraftAttempt.slot = lastSlotUsed
 				lastSlotUsed = nil
-				return LLC_EnchantingCraftingComplete(event, station, lastCheck)
+				return LLC_EnchantingCraftingComplete(station, lastCheck)
 		end
 	else
 		-- further search
 		-- search again later
-		if GetCraftingInteractionType()==0 then zo_callLater(function() LLC_EnchantingCraftingComplete(event, station, true) end,100) end
+		if GetCraftingInteractionType()==0 then zo_callLater(function() LLC_EnchantingCraftingComplete(station, true) end,100) end
 	end
 
 

--- a/LibLazyCrafting.lua
+++ b/LibLazyCrafting.lua
@@ -409,7 +409,8 @@ end
 local function sortCraftQueue()
 	for name, requests in pairs(craftingQueue) do
 		for i = 1, 6 do
-			table.sort(requests[i], function(a, b) if a and b then return a["timestamp"]<b["timestamp"] else return a end end)
+			table.sort(requests[i], function(a, b) return (a and a.timestamp or 0) < (b and b.timestamp or 0)
+			end)
 		end
 	end
 end
@@ -838,7 +839,7 @@ local function CraftInteract(event, station)
 		if DeconEarliest(event, station) then
 			return
 		end
-		LibLazyCrafting.SendCraftEvent( LLC_NO_FURTHER_CRAFT_POSSIBLE ,  station, addon , nil )
+		LibLazyCrafting.SendCraftEvent( LLC_NO_FURTHER_CRAFT_POSSIBLE ,  station, nil , nil )
 		return
 	end
 	for k,v in pairs(LibLazyCrafting.craftInteractionTables) do
@@ -848,7 +849,7 @@ local function CraftInteract(event, station)
 			end
 		end
 	end
-	LibLazyCrafting.SendCraftEvent( LLC_NO_FURTHER_CRAFT_POSSIBLE ,  station,addon , nil )
+	LibLazyCrafting.SendCraftEvent( LLC_NO_FURTHER_CRAFT_POSSIBLE ,  station, nil , nil )
 end
 
 LibLazyCrafting.craftInteract = CraftInteract

--- a/Smithing.lua
+++ b/Smithing.lua
@@ -27,7 +27,6 @@ if GetDisplayName() == "@Dolgubon" then
 	DolgubonGlobalDebugOutput = d
 end
 local function dbug(...)
-	-- d(...)
 	if DolgubonGlobalDebugOutput then
 		DolgubonGlobalDebugOutput(...)
 	end
@@ -425,7 +424,7 @@ function LibLazyCrafting.getPatternFromResearchLine(station, researchLine)
 		local map = {
 			1, 3,4,5,6,2
 		}
-		return map[pattern]
+		return map[researchLine]
 	end
 	return researchLine
 end
@@ -508,7 +507,6 @@ end
 
 -- Returns SetIndex, Set Full Name, Traits Required
 local function GetCurrentSetInteractionIndex()
-	local baseSetPatternName
 	local itemLink
 	local currentStation = GetCraftingInteractionType()
 	-- Get info based on what station it is.
@@ -519,7 +517,7 @@ local function GetCurrentSetInteractionIndex()
 	elseif currentStation == CRAFTING_TYPE_WOODWORKING then
 		itemLink = GetSmithingPatternResultLink(7,1,3,1,1,0)
 	elseif currentStation == CRAFTING_TYPE_JEWELRYCRAFTING then
-		itemLink = GetSmithingPatternResultLink(4,1,3,nil,1,0)
+		itemLink = GetSmithingPatternResultLink(4,1,3,0,1,0)
 	else
 		return nil , nil, nil, nil
 	end
@@ -750,7 +748,7 @@ local function LLC_CraftSmithingItem(self, patternIndex, materialIndex, material
 	requestTable["Requester"] = self.addonName
 	requestTable["reference"] = reference
 	requestTable["smithingQuantity"] = smithingQuantity or 1
-	requestTable["initialQuantity"] = quantity
+	requestTable["initialQuantity"] = smithingQuantity or 1
 	if GetSetIndexes()[setIndex] and GetSetIndexes()[setIndex].isSwapped and station == CRAFTING_TYPE_JEWELRYCRAFTING then -- New Moon Acolyte pattern indexes and beyond are swapped for jewelry!
 		requestTable.isJewelrySwapped = true
 		if requestTable.pattern == 1 then
@@ -949,7 +947,7 @@ local function LLC_CraftSmithingItemFromLink(self, itemLink, reference)
 	else
 		if weight == ARMORTYPE_HEAVY then
 			station = CRAFTING_TYPE_BLACKSMITHING
-		elseif weight == ARMORTYPE_LIGHT or ARMORTYPE_MEDIUM then
+		elseif weight == ARMORTYPE_LIGHT or weight == ARMORTYPE_MEDIUM then
 			station = CRAFTING_TYPE_CLOTHIER
 		end
 		pattern = getPatternInfo(itemLink, weight)
@@ -1179,7 +1177,7 @@ end
 
 LibLazyCrafting.functionTable.DeconstructSmithingItem = LLC_DeconstructItem
 
-LibLazyCrafting.functionTable.AddExistingGlyphToGear = LLC_AddExistingGlyph
+LibLazyCrafting.functionTable.AddExistingGlyphToGear = LLC_AddExistingGlyphToGear
 
 LibLazyCrafting.functionTable.ImproveSmithingItem = LLC_ImproveSmithingItem
 -- Examples
@@ -1229,7 +1227,7 @@ local function setCorrectSetIndex_ConsolidatedStation(setIndex)
 			generateSetLookupTable()
 		end
 		if not IsConsolidatedSmithingItemSetIdUnlocked(setIndex) and setIndex ~= 0 then
-			local _, setName = GetItemSetInfo(setindex)
+			local _, setName = GetItemSetInfo(setIndex)
 			d(zo_strformat("The set <<1>> is not unlocked at this crafting station", setName ))
 			return
 		end
@@ -1562,6 +1560,7 @@ local function smithingCompleteNewItemHandler(station, bag, slot)
 				})
 				removedRequest.equipCreated = true
 				if removedRequest.glyphInfo and #removedRequest.glyphInfo>0 then
+					d("Applying glyph to newly crafted item")
 					LibLazyCrafting.applyGlyphToItem(removedRequest)
 					return
 				else
@@ -1624,7 +1623,7 @@ local function SmithingCraftCompleteFunction(station)
 					else
 						LibLazyCrafting:SetItemStatusNew(returnTable.ItemSlotID)
 						local copiedTable = LibLazyCrafting.tableShallowCopy(returnTable)
-						copiedTable.slot = slot
+						copiedTable.slot = returnTable.ItemSlotID
 						copiedTable.smithingQuantity = 1
 						LibLazyCrafting.SendCraftEvent( LLC_INITIAL_CRAFT_SUCCESS,  station,copiedTable.Requester, copiedTable )
 					end
@@ -1681,7 +1680,7 @@ local function slotUpdateHandler(event, bag, slot, isNew, itemSoundCategory, inv
 	local itemType = GetItemType(bag, slot)
 	if itemType ==ITEMTYPE_ARMOR or itemType ==ITEMTYPE_WEAPON then else return end
 	hasNewItemBeenMade = true
-	if LibLazyCrafting.IsPerformingCraftProcess() and ( currentCraftAttempt.slot ~= slot or not currentCraftAttempt.slot ) then
+	if LibLazyCrafting:IsPerformingCraftProcess() and ( currentCraftAttempt.slot ~= slot or not currentCraftAttempt.slot ) then
 		backupPosition = slot
 
 	end
@@ -2202,8 +2201,10 @@ local function getItemLinkFromRequest(requestTable)
 		linkTable = {}
 		linkTable.id = setId
 		local IdTable = createSetItemIdTable(setId)
-		for i, v in pairs(IdTable) do
-			linkTable[i] = getItemLinkFromItemId(IdTable[i])
+		if IdTable then
+			for i, v in pairs(IdTable) do
+				linkTable[i] = getItemLinkFromItemId(IdTable[i])
+			end
 		end
 
 	end
@@ -2326,7 +2327,7 @@ end
 
 local function getNonCraftableReasons(request)
 	local results = {}
-	results.canCraftHere =  canCraftItemHere(station, request["setIndex"])
+	results.canCraftHere =  canCraftItemHere(request["station"], request["setIndex"])
 	local canCraft, canCraftMissings = canCraftItem(request)
 	local enoughMats, missingMats = enoughMaterials(request)
 	results.missingKnowledge = canCraftMissings

--- a/Smithing.lua
+++ b/Smithing.lua
@@ -1560,7 +1560,6 @@ local function smithingCompleteNewItemHandler(station, bag, slot)
 				})
 				removedRequest.equipCreated = true
 				if removedRequest.glyphInfo and #removedRequest.glyphInfo>0 then
-					d("Applying glyph to newly crafted item")
 					LibLazyCrafting.applyGlyphToItem(removedRequest)
 					return
 				else


### PR DESCRIPTION
Fix multiple issues in LibLazyCrafting and Enchanting flow

- Fix enchanting glyph queue handling to correctly apply multiple glyphs when crafting glyphs before armor items, preventing partial application of pending enchantments
- Fix invalid armor type condition in Smithing logic
- Fix undefined / incorrectly scoped variables in crafting events
- Fix pattern mapping error in research line lookup
- Improve table clearing to properly handle dictionary tables
- Fix incorrect slot handling and completion flow in crafting callbacks
- Minor safety and consistency fixes across crafting queue and helpers

These changes were tested locally.